### PR TITLE
SRE-50: Adds Datadog agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* Added datadog agent api key and version variables to
+  `module_groups/ecs_fargate_with_elb`.
+* Added datadog agent container task definition to
+  `modules/ecs_service_fargate_elb`.
+* Added additional permission to fargate task role policy to allow datadog
+  agent perform autodiscovery.
+
 ### Added
 ### Changed
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-* Added datadog agent api key and version variables to
-  `module_groups/ecs_fargate_with_elb`.
-* Added datadog agent container task definition to
-  `modules/ecs_service_fargate_elb`.
-* Added additional permission to fargate task role policy to allow datadog
-  agent perform autodiscovery.
+* Added datadog agent api key and version variables to `module_groups/ecs_fargate_with_elb`.
+* Added datadog agent container task definition to `modules/ecs_service_fargate_elb`.
+* Added additional permission to fargate task role policy to allow datadog agent perform autodiscovery. When upgrading, please apply these changes using nulogy-deployer locally before doing a deploy because Buildkite role does not have permissions to change task role policy:
+
+```
+cd app_worker
+terragrunt plan -var docker_image=<YOUR_CURRENT_DEPLOYED_GIT_HASH>
+```
 
 ### Added
 ### Changed

--- a/module_groups/ecs_fargate_with_elb/main.tf
+++ b/module_groups/ecs_fargate_with_elb/main.tf
@@ -34,6 +34,8 @@ module "ecs_service_fargate_elb" {
   command               = var.command
   container_port        = var.container_port
   cpu                   = var.cpu
+  datadog_api_key       = var.datadog_api_key
+  datadog_agent_version = var.datadog_agent_version
   desired_count         = var.desired_count
   docker_image_name     = var.docker_image_name
   ecs_cluster_name      = var.ecs_cluster_name

--- a/module_groups/ecs_fargate_with_elb/variables.tf
+++ b/module_groups/ecs_fargate_with_elb/variables.tf
@@ -137,7 +137,7 @@ variable "ecs_incoming_allowed_cidr" {
 }
 
 variable "datadog_api_key" {
-  description = "Datadog API key. This will activate the Datadog agent sidecar/replica container. To accommodate additional load, please increase var.cpu to an additional 512 or more. Similarly, increase var.memory to an additional 1024."
+  description = "Datadog API key. This will activate the Datadog agent sidecar/replica container on the same ECS task. Please adjust var.cpu and/or var.memory to accommodate if necessary."
   default     = ""
   type        = string
 }

--- a/module_groups/ecs_fargate_with_elb/variables.tf
+++ b/module_groups/ecs_fargate_with_elb/variables.tf
@@ -135,3 +135,15 @@ variable "ecs_incoming_allowed_cidr" {
   description = "The CIDR to allow incoming traffic to the ECS tasks.  Overrides the default of the VPC"
   default     = ""
 }
+
+variable "datadog_api_key" {
+  description = "Datadog API key. This will activate the Datadog agent sidecar/replica container. To accommodate additional load, please increase var.cpu to an additional 512 or more. Similarly, increase var.memory to an additional 1024."
+  default     = ""
+  type        = string
+}
+
+variable "datadog_agent_version" {
+  description = "Datadog agent container version."
+  default     = "latest"
+  type        = string
+}

--- a/modules/ecs_service_fargate_elb/iam.tf
+++ b/modules/ecs_service_fargate_elb/iam.tf
@@ -59,7 +59,10 @@ resource "aws_iam_role_policy" "fargate_task_execution_role_policy" {
         "ecr:GetDownloadUrlForLayer",
         "ecr:BatchGetImage",
         "logs:CreateLogStream",
-        "logs:PutLogEvents"
+        "logs:PutLogEvents",
+        "ecs:ListClusters",
+        "ecs:ListContainerInstances",
+        "ecs:DescribeContainerInstances"
       ],
       "Resource": "*"
     }

--- a/modules/ecs_service_fargate_elb/variables.tf
+++ b/modules/ecs_service_fargate_elb/variables.tf
@@ -1,5 +1,6 @@
 variable "cpu" {
-  description = "CPU per Fargate container. Units are 1024 = 1 vCPU."
+  description = "CPU per Fargate task. Units are 1024 = 1 vCPU."
+  type        = number
 }
 
 variable "command" {
@@ -61,7 +62,8 @@ variable "vpc_id" {
 }
 
 variable "memory" {
-  description = "Memory per Fargate container."
+  description = "Memory per Fargate task."
+  type        = number
 }
 
 variable "param_store_namespace" {
@@ -86,3 +88,32 @@ variable "target_group_arn" {
   description = "Target of an Amazon ALB (Load Balancer), as given by a load balancer."
 }
 
+variable "datadog_api_key" {
+  description = "Datadog API key. This will activate the Datadog agent sidecar/replica container. To accommodate additional load, please increase var.cpu to an additional 512. Similarly, increase var.memory to an additional 1024."
+  default     = ""
+  type        = string
+}
+
+variable "datadog_agent_version" {
+  description = "Datadog agent container version."
+  default     = "latest"
+  type        = string
+}
+
+variable "datadog_agent_cpu" {
+  description = "Datadog agent container cpu. Units are 1024 = 1 vCPU."
+  default     = 256
+  type        = number
+}
+
+variable "datadog_agent_memoryReservation" {
+  description = "Datadog agent container memory soft limit. Units are in MB."
+  default     = 512
+  type        = number
+}
+
+variable "datadog_agent_memory" {
+  description = "Datadog agent container memory hard limit. Units are in MB."
+  default     = 1024
+  type        = number
+}

--- a/modules/ecs_service_fargate_elb/variables.tf
+++ b/modules/ecs_service_fargate_elb/variables.tf
@@ -89,7 +89,7 @@ variable "target_group_arn" {
 }
 
 variable "datadog_api_key" {
-  description = "Datadog API key. This will activate the Datadog agent sidecar/replica container. To accommodate additional load, please increase var.cpu to an additional 512. Similarly, increase var.memory to an additional 1024."
+  description = "Datadog API key. This will activate the Datadog agent sidecar/replica container on the same ECS task. Please adjust var.cpu and/or var.memory to accommodate if necessary."
   default     = ""
   type        = string
 }
@@ -98,22 +98,4 @@ variable "datadog_agent_version" {
   description = "Datadog agent container version."
   default     = "latest"
   type        = string
-}
-
-variable "datadog_agent_cpu" {
-  description = "Datadog agent container cpu. Units are 1024 = 1 vCPU."
-  default     = 256
-  type        = number
-}
-
-variable "datadog_agent_memoryReservation" {
-  description = "Datadog agent container memory soft limit. Units are in MB."
-  default     = 512
-  type        = number
-}
-
-variable "datadog_agent_memory" {
-  description = "Datadog agent container memory hard limit. Units are in MB."
-  default     = 1024
-  type        = number
 }


### PR DESCRIPTION
* Added datadog agent api key and version variables to `module_groups/ecs_fargate_with_elb`.
* Added datadog agent container task definition to `modules/ecs_service_fargate_elb`.
* Added additional permission to fargate task role policy to allow datadog agent perform autodiscovery.