### PR TITLE
SRE-194: Injects DATADOG_SERVICE env var in the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* Injects `DATADOG_SERVICE` env var into the app (feature flag for initializer)
+
 ### Added
 ### Changed
 ### Deprecated
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 ### Security
 
-## [11.3.1] - 2020-06-05
+## [11.3.2] - 2020-06-10
 
 ### Fixed
 


### PR DESCRIPTION
- Injects DATADOG_SERVICE env var so the app can feature flag Datadog tracer at the initializer level
- DATADOG_SERVICE is only injected when the Datadog agent sidecar is available
- This will unblock Test environment from running into freezing situations
- The root cause for freezing is not yet discovered but this is a feature that was on the plan, so I am merging this as a feature fix :)