### PR TITLE
TASS-140: adds an output to buildkite elastic stack for getting the instance role name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+* Output for instance_role_name of buildkite stack
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/modules/buildkite_elastic_stack/outputs.tf
+++ b/modules/buildkite_elastic_stack/outputs.tf
@@ -2,3 +2,6 @@ output "security_group_id" {
   value = aws_security_group.stack_security_group.id
 }
 
+output "instance_role_name" {
+  value = aws_cloudformation_stack.stack.outputs["InstanceRoleName"]
+}


### PR DESCRIPTION
So we can attach policies for deploying infrastructure to this role.