### PR TITLE
Selects most recent ACM certificate when there are more than one eligible, instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 ### Security
 
+## [12.1.1] - 2020-07-08
+
+### Fixed
+
+* Selects most recent ACM certificate when there are more than one eligible, instead of crashing
+
 ## [12.1.0] - 2020-07-03
 
 ### Added

--- a/modules/amqp_load_balancer/main.tf
+++ b/modules/amqp_load_balancer/main.tf
@@ -1,5 +1,6 @@
 data "aws_acm_certificate" "acm_region_cert" {
   domain = "*.${var.certificate_domain}"
+  most_recent = true
 }
 
 resource "aws_elb" "elb" {

--- a/modules/public_load_balancer/data_cert.tf
+++ b/modules/public_load_balancer/data_cert.tf
@@ -2,5 +2,6 @@ data "aws_acm_certificate" "acm_region_cert" {
   count = length(var.skip) > 0 ? 0 : (length(var.lb_cert_arn) > 0 ? 0 : 1)
 
   domain = var.cert_domain
+  most_recent = true
 }
 


### PR DESCRIPTION
This is the same change as https://github.com/nulogy/nulogy-deployer/pull/42/files.