### PR TITLE
Adds a version of the ecs_service_fargate module that ignores desired_count changes so it can remain compatible with AWS autoscaling rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 ### Security
 
+## [13.0.1] - 2020-07-09
+
+### Added
+
+* ecs_service_fargate_autoscaling, which is a version of the module that ignores desired_count changes so it can remain compatible with AWS autoscaling rules
+
 ## [13.0.0] - 2020-07-09
 
 ### Changed

--- a/modules/ecs_service_fargate/README.md
+++ b/modules/ecs_service_fargate/README.md
@@ -1,5 +1,5 @@
 ## ECS Fargate Service
 
-Use this module to create a service on ECS which does not require a load balancer. e.g. background workers.
-
-* Add any autoscaling rules on top.
+Use this module to create a service on ECS which does not require a load balancer. e.g. background workers. A static
+desired_count is provided to this module, which may not be appropriate for auto-scaled workloads. See 
+[the ecs_service_fargate_autoscaling](../ecs_service_fargate_autoscaling/README.md) module's README for more information.

--- a/modules/ecs_service_fargate_autoscaling/README.md
+++ b/modules/ecs_service_fargate_autoscaling/README.md
@@ -1,0 +1,8 @@
+## ECS Fargate Service with Autoscaling support
+
+Use this module to create a service on ECS which does not require a load balancer. e.g. background workers.
+
+Despite the name, this module doesn't actually configure the autoscaling. It simply sets the ignore_changes lifecycle
+attribute on the desired count of the ecs service so that terraform doesn't fight with any autoscaling rules you add
+somewhere else.
+

--- a/modules/ecs_service_fargate_autoscaling/iam.tf
+++ b/modules/ecs_service_fargate_autoscaling/iam.tf
@@ -1,0 +1,111 @@
+data "aws_caller_identity" "current" {
+}
+
+data "aws_region" "current" {
+}
+
+resource "aws_iam_role" "ecs_taskrole" {
+  name               = "${var.environment_name}-ecs-${var.service_name}-task"
+  assume_role_policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role" "ecs_executionrole" {
+  name               = "${var.environment_name}-ecs-${var.service_name}-execution-role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy" "fargate_task_execution_role_policy" {
+  name   = "${var.environment_name}-fargate-ecs-${var.service_name}-task-execution"
+  role   = aws_iam_role.ecs_executionrole.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy" "parameter_store_policy" {
+  name   = "${var.environment_name}-${var.service_name}-parameter-store"
+  role   = aws_iam_role.ecs_taskrole.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeParameters"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:PutParameter"
+      ],
+      "Resource": [
+        "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.param_store_namespace}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/${var.kms_key_id}"
+      ]
+    }
+  ]
+}
+EOF
+
+}
+

--- a/modules/ecs_service_fargate_autoscaling/iam.tf
+++ b/modules/ecs_service_fargate_autoscaling/iam.tf
@@ -87,8 +87,7 @@ resource "aws_iam_role_policy" "parameter_store_policy" {
       "Effect": "Allow",
       "Action": [
         "ssm:GetParameter",
-        "ssm:GetParameters",
-        "ssm:PutParameter"
+        "ssm:GetParameters"
       ],
       "Resource": [
         "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.param_store_namespace}/*"

--- a/modules/ecs_service_fargate_autoscaling/main.tf
+++ b/modules/ecs_service_fargate_autoscaling/main.tf
@@ -1,0 +1,50 @@
+locals {
+  task_def_json = length(var.task_definition_json) > 0 ? var.task_definition_json : "${path.module}/task_definition/default.json"
+}
+
+data "template_file" "template" {
+  template = file(local.task_def_json)
+
+  vars = {
+    TPL_CPU             = var.cpu
+    TPL_DOCKER_IMAGE    = var.docker_image_name
+    TPL_ENV_NAME        = var.environment_name
+    TPL_SERVICE_NAME    = var.service_name
+    TPL_LOG_GROUP_NAME  = var.log_group_name
+    TPL_REGION          = data.aws_region.current.name
+    TPL_ENVVARS         = var.envars
+    TPL_MEM_RESERVATION = var.memory / var.containers_per_task
+    TPL_MEM             = var.memory / var.containers_per_task
+    TPL_COMMAND         = join("\",\"", var.command)
+    TPL_HEALTH_CHECK    = join("\",\"", var.health_check)
+  }
+}
+
+resource "aws_ecs_task_definition" "ecs_task" {
+  cpu                      = var.cpu
+  memory                   = var.memory
+  family                   = "${var.environment_name}_${var.service_name}_td"
+  task_role_arn            = aws_iam_role.ecs_taskrole.arn
+  execution_role_arn       = aws_iam_role.ecs_executionrole.arn
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  container_definitions    = data.template_file.template.rendered
+}
+
+resource "aws_ecs_service" "ecs_service" {
+  name            = "${var.environment_name}_${var.service_name}_service"
+  cluster         = var.ecs_cluster_name
+  task_definition = aws_ecs_task_definition.ecs_task.arn
+  launch_type     = "FARGATE"
+  desired_count   = var.desired_count
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  network_configuration {
+    subnets         = var.subnets
+    security_groups = var.security_groups
+  }
+}
+

--- a/modules/ecs_service_fargate_autoscaling/outputs.tf
+++ b/modules/ecs_service_fargate_autoscaling/outputs.tf
@@ -1,0 +1,12 @@
+output "ecs_service_name" {
+  value = aws_ecs_service.ecs_service.name
+}
+
+output "task_arn" {
+  value = aws_ecs_task_definition.ecs_task.arn
+}
+
+output "iam_id" {
+  value = aws_iam_role.ecs_taskrole.id
+}
+

--- a/modules/ecs_service_fargate_autoscaling/outputs.tf
+++ b/modules/ecs_service_fargate_autoscaling/outputs.tf
@@ -6,7 +6,7 @@ output "task_arn" {
   value = aws_ecs_task_definition.ecs_task.arn
 }
 
-output "iam_id" {
+output "task_role_id" {
   value = aws_iam_role.ecs_taskrole.id
 }
 

--- a/modules/ecs_service_fargate_autoscaling/task_definition/default.json
+++ b/modules/ecs_service_fargate_autoscaling/task_definition/default.json
@@ -1,0 +1,27 @@
+[
+  {
+    "command": ["${TPL_COMMAND}"],
+    "environment": ${TPL_ENVVARS},
+    "essential": true,
+    "image": "${TPL_DOCKER_IMAGE}",
+    "cpu": ${TPL_CPU},
+    "memoryReservation": ${TPL_MEM_RESERVATION},
+    "memory": ${TPL_MEM},
+    "name": "${TPL_ENV_NAME}_${TPL_SERVICE_NAME}",
+    "healthCheck": {
+      "command": ["${TPL_HEALTH_CHECK}"],
+      "interval": 30,
+      "timeout": 5,
+      "retries": 3,
+      "startPeriod": null
+    },
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+          "awslogs-group": "${TPL_LOG_GROUP_NAME}",
+          "awslogs-region": "${TPL_REGION}",
+          "awslogs-stream-prefix": "${TPL_ENV_NAME}"
+      }
+    }
+  }
+]

--- a/modules/ecs_service_fargate_autoscaling/variables.tf
+++ b/modules/ecs_service_fargate_autoscaling/variables.tf
@@ -1,0 +1,77 @@
+variable "cpu" {
+  description = "CPU per Fargate container. Units are 1024 = 1 vCPU."
+}
+
+variable "desired_count" {
+  description = "How many Fargate containers to run initially."
+}
+
+variable "docker_image_name" {
+  description = "Which docker container to run. e.g. 501253995157.dkr.ecr.us-east-1.amazonaws.com/packmanager-qa-dev:0.1.2"
+}
+
+variable "ecs_cluster_name" {
+  description = "The name of the cluster to run this service in."
+}
+
+variable "envars" {
+  description = "JSON format environment variables to pass into the container task."
+}
+
+variable "environment_name" {
+  description = "Environment name. Used for tagging."
+}
+
+variable "service_name" {
+  description = "Service name. Used for tagging."
+}
+
+variable "kms_key_id" {
+  description = "KMS Key to retrieve secrets with. Goes with param store namespace."
+}
+
+variable "log_group_name" {
+  description = "The place to send Cloudwatch logs for the container's process. Base this on environment name."
+}
+
+variable "memory" {
+  description = "Memory per Fargate container."
+}
+
+variable "param_store_namespace" {
+  default = "Path for SSM secret parameters that the container needs permission to access."
+}
+
+variable "security_groups" {
+  description = "Security groups for the container. Determines inbound and outbound connections / ports."
+  type        = list(string)
+}
+
+variable "subnets" {
+  description = "Determines the AZ for the containers. Usually put all subnets from the VPC."
+  type        = list(string)
+}
+
+variable "command" {
+  description = "Commands to execute after entrypoint"
+  default     = ["/bin/echo", "Start command not supplied, just exiting"]
+  type        = list(string)
+}
+
+variable "health_check" {
+  description = "Commands to execute a container health check"
+  default     = ["CMD-SHELL", "echo OK || exit 1"]
+  type        = list(string)
+}
+
+variable "task_definition_json" {
+  description = "allows specifying a different JSON task definition, if none default (1 container per task) will be used"
+  default     = ""
+  type        = string
+}
+
+variable "containers_per_task" {
+  description = "Number of container to run per task. Used to specify the amount of memory for each container if running multiple per task."
+  default     = 1
+}
+

--- a/modules/ecs_service_fargate_autoscaling/versions.tf
+++ b/modules/ecs_service_fargate_autoscaling/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Unfortunately there's no way to avoid code duplication while https://github.com/hashicorp/terraform/issues/3116 is still unsolved