### PR TITLE
TASS-318: adds security groups to ecs_scheduled_task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+* Adds security groups variable to ecs_scheduled_task module
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/modules/ecs_scheduled_task/main.tf
+++ b/modules/ecs_scheduled_task/main.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_event_target" "scheduled_task_event_target" {
     network_configuration {
       subnets = var.subnets
       assign_public_ip = false
-
+      security_groups = var.security_groups
     }
   }
 }

--- a/modules/ecs_scheduled_task/variables.tf
+++ b/modules/ecs_scheduled_task/variables.tf
@@ -16,6 +16,11 @@ variable "event_target_json" {
 variable "schedule_expression" {
 }
 
+variable "security_groups" {
+  default = []
+  type = list(string)
+}
+
 variable "skip" {
   default = ""
 }


### PR DESCRIPTION
ECS task inocations are failing on the new ECO infrastructure (in the shared VPC in us-east-1). My hypothesis is that something specific about the shared VPC makes security groups required, but I haven't confirmed the hypothesis.
For reference, this is the PR in ECO https://github.com/nulogy/eco/pull/857

**Note**: This module is currently only used by ECO, so it might make sense to just inline it in the ECO repo