### PR TITLE
PM-8371: Add a cloudwatch_logzio module for log shipping to Logz.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 ### Security
 
+### Added
+
+* `cloudwatch_logzio` module that can be used to send logs to Logz.io
+
 ## [18.0.0] - 2020-11-16
 
 ### Changed

--- a/modules/cloudwatch_logzio/main.tf
+++ b/modules/cloudwatch_logzio/main.tf
@@ -1,0 +1,95 @@
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_dir = "${path.module}/src"
+  output_path = "lambda.zip"
+}
+
+resource "aws_lambda_function" "lambda" {
+  filename         = "lambda.zip"
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  function_name    = "${replace(var.environment_name, "packmanager", "pm")}-${var.logzio__module_name}-ship-logzio"
+  role             = aws_iam_role.lambda_role.arn
+  description      = "AWS Lambda Function that ingests CloudWatch logs into Logz.io. Environment: ${var.environment_name}. Terraform Module: ${var.logzio__module_name}."
+  handler          = "lambda.lambda_handler"
+  runtime          = "python2.7"
+  timeout          = "30"
+
+  environment {
+    variables = {
+      FORMAT = var.logzio__logs_format
+      TOKEN  = data.aws_ssm_parameter.logzio__api_key.value
+      TYPE   = var.logzio__logs_type
+      URL    = var.logzio__api_url
+    }
+  }
+
+  lifecycle {
+    # Ignore changes to environment variables values.
+    # @TODO: In order to get this done automatically, we need to improve the 'lambda.py'
+    #script so we can retrieve the values from Parameter Store programatically.
+    ignore_changes = [environment]
+  }
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "logfilter" {
+  name            = "logzio_logfilter"
+  log_group_name  = var.logzio__log_group_name
+  filter_pattern  = ""
+  destination_arn = aws_lambda_function.lambda.arn
+  distribution    = "ByLogStream"
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name               = "${replace(var.environment_name, "packmanager", "pm")}-${var.logzio__module_name}-cloudwatch-to-logzio"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_lambda_permission" "allows_cloudwatch_execute_lambda" {
+  statement_id  = "${replace(var.environment_name, "packmanager", "pm")}-${var.logzio__module_name}-allows-cloudwatch-execute-lambda"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda.arn
+  principal     = "logs.${var.aws_region}.amazonaws.com"
+  source_arn    = var.logzio__log_group_arn
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  name        = "${replace(var.environment_name, "packmanager", "pm")}-${var.logzio__module_name}-cloudwatch-to-logzio"
+  description = "Allows Lambda to write its execution logs into CloudWatch."
+  policy      = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
+  policy_arn = aws_iam_policy.lambda_policy.arn
+  role       = aws_iam_role.lambda_role.name
+}
+

--- a/modules/cloudwatch_logzio/output.tf
+++ b/modules/cloudwatch_logzio/output.tf
@@ -1,0 +1,4 @@
+output "aws_lambda_function" {
+  value = aws_lambda_function.lambda.function_name
+}
+

--- a/modules/cloudwatch_logzio/setup.tf
+++ b/modules/cloudwatch_logzio/setup.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  version = "2.70.0"
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+provider "archive" {
+  version = "1.2.2"
+}
+
+# This token is manually added into AWS accounts that have environments that require the Logz.io module
+data "aws_ssm_parameter" "logzio__api_key" {
+  name = "/logzio/api-key"
+}
+

--- a/modules/cloudwatch_logzio/src/lambda.py
+++ b/modules/cloudwatch_logzio/src/lambda.py
@@ -1,0 +1,69 @@
+import gzip
+import json
+import logging
+import os
+
+from log_shipper import LogzioShipper
+from StringIO import StringIO
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _extract_aws_logs_data(event):
+  try:
+    logs_data_decoded = event['awslogs']['data'].decode('base64')
+    logs_data_unzipped = gzip.GzipFile(fileobj=StringIO(logs_data_decoded)).read()
+    logs_data_dict = json.loads(logs_data_unzipped)
+    return logs_data_dict
+  except ValueError as e:
+    logger.error("Got exception while loading json, message: {}".format(e))
+    raise ValueError("Exception: json loads")
+
+def _parse_cloudwatch_log(log, aws_logs_data, log_type):
+  if '@timestamp' not in log:
+    log['@timestamp'] = str(log['timestamp'])
+    del log['timestamp']
+  log['message'] = log['message'].replace('\n', '')
+  log['logStream'] = aws_logs_data['logStream']
+  log['messageType'] = aws_logs_data['messageType']
+  log['owner'] = aws_logs_data['owner']
+  log['logGroup'] = aws_logs_data['logGroup']
+  log['function_version'] = aws_logs_data['function_version']
+  log['invoked_function_arn'] = aws_logs_data['invoked_function_arn']
+  log['type'] = log_type
+  try:
+    if os.environ['FORMAT'].lower() == 'json':
+      json_object = json.loads(log['message'])
+      for key, value in json_object.items():
+        log[key] = value
+  except (KeyError, ValueError):
+    pass
+
+def _enrich_logs_data(aws_logs_data, context):
+  try:
+    aws_logs_data['function_version'] = context.function_version
+    aws_logs_data['invoked_function_arn'] = context.invoked_function_arn
+  except KeyError:
+    pass
+
+def lambda_handler(event, context):
+  try:
+    if os.environ['TOKEN'] == 'CHANGEME':
+      logger.error("You need to change the TOKEN environment variable value other than default.")
+      raise
+    logzio_url = "{0}/?token={1}".format(os.environ['URL'], os.environ['TOKEN'])
+    log_type = (os.environ['TYPE'])
+  except KeyError as e:
+    logger.error("Missing one of the environment variable: {}".format(e))
+    raise
+  aws_logs_data = _extract_aws_logs_data(event)
+  _enrich_logs_data(aws_logs_data, context)
+  shipper = LogzioShipper(logzio_url)
+  logger.info("About to send {} logs".format(len(aws_logs_data['logEvents'])))
+  for log in aws_logs_data['logEvents']:
+    if not isinstance(log, dict):
+      raise TypeError("Expected log inside logEvents to be a dict but found another type")
+    _parse_cloudwatch_log(log, aws_logs_data, log_type)
+    shipper.add(log)
+  shipper.flush()

--- a/modules/cloudwatch_logzio/src/log_shipper.py
+++ b/modules/cloudwatch_logzio/src/log_shipper.py
@@ -1,0 +1,107 @@
+import json
+import logging
+import sys
+import time
+import urllib2
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class MaxRetriesException(Exception):
+  pass
+
+
+class UnauthorizedAccessException(Exception):
+  pass
+
+
+class BadLogsException(Exception):
+  pass
+
+
+class UnknownURL(Exception):
+  pass
+
+
+class LogzioShipper(object):
+  MAX_BULK_SIZE_IN_BYTES = 1 * 1024 * 1024
+
+  def __init__(self, logzio_url):
+    self._size = 0
+    self._logs = []
+    self._logzio_url = logzio_url
+
+  def add(self, log):
+    json_log = json.dumps(log)
+    self._logs.append(json_log)
+    self._size += sys.getsizeof(json_log)
+    self._try_to_send()
+
+  def _reset(self):
+    self._size = 0
+    self._logs = []
+
+  def _try_to_send(self):
+    if self._size > self.MAX_BULK_SIZE_IN_BYTES:
+      self._send_to_logzio()
+      self._reset()
+
+  def flush(self):
+    if self._size:
+      self._send_to_logzio()
+      self._reset()
+
+  @staticmethod
+  def retry(func):
+    def retry_func():
+      max_retries = 4
+      sleep_between_retries = 2
+      for retries in xrange(max_retries):
+        if retries:
+          sleep_between_retries *= 2
+          logger.info("Failure in sending logs - Trying again in {} seconds".format(sleep_between_retries))
+          time.sleep(sleep_between_retries)
+        try:
+          res = func()
+        except urllib2.HTTPError as e:
+          status_code = e.getcode()
+          if status_code == 400:
+            raise BadLogsException(e.reason)
+          elif status_code == 401:
+            raise UnauthorizedAccessException()
+          elif status_code == 404:
+            raise UnknownURL()
+          else:
+            logger.error("Unknown HTTP exception: {}".format(e))
+            continue
+        except urllib2.URLError:
+          raise
+        return res
+      raise MaxRetriesException()
+    return retry_func
+
+  def _send_to_logzio(self):
+    @LogzioShipper.retry
+    def do_request():
+      headers = {"Content-type": "application/json"}
+      request = urllib2.Request(self._logzio_url, data='\n'.join(self._logs), headers=headers)
+      return urllib2.urlopen(request)
+    try:
+      do_request()
+      logger.info("Successfully sent bulk of {} logs to Logz.io!".format(len(self._logs)))
+    except MaxRetriesException:
+      logger.error('Retry limit reached. Failed to send log entry.')
+      raise MaxRetriesException()
+    except BadLogsException as e:
+      logger.error("Got 400 code from Logz.io. This means that some of your logs are too big, or badly formatted. response: {0}".format(e.message))
+      raise BadLogsException()
+    except UnauthorizedAccessException:
+      logger.error("You are not authorized with Logz.io! Token OK? dropping logs...")
+      raise UnauthorizedAccessException()
+    except UnknownURL:
+      logger.error("Please check your url...")
+      raise UnknownURL()
+    except urllib2.HTTPError as e:
+      logger.error("Unexpected error while trying to send logs: {}".format(e))
+      raise

--- a/modules/cloudwatch_logzio/variables.tf
+++ b/modules/cloudwatch_logzio/variables.tf
@@ -6,6 +6,9 @@ variable "aws_profile" {
 variable "environment_name" {
 }
 
+variable "environment_short_name" {
+}
+
 variable "logzio__api_url" {
   default = "https://listener.logz.io:8071"
 }

--- a/modules/cloudwatch_logzio/variables.tf
+++ b/modules/cloudwatch_logzio/variables.tf
@@ -1,0 +1,30 @@
+variable "aws_region" {
+}
+variable "aws_profile" {
+}
+
+variable "environment_name" {
+}
+
+variable "logzio__api_url" {
+  default = "https://listener.logz.io:8071"
+}
+
+variable "logzio__logs_format" {
+  default = "JSON"
+}
+
+variable "logzio__logs_type" {
+  default = "cloudwatch"
+}
+
+variable "logzio__module_name" {
+  description = "The module which wants to integrate its logs from cloudwatch to logzio. (e.g.: resque_scheduler)"
+}
+
+variable "logzio__log_group_name" {
+}
+
+variable "logzio__log_group_arn" {
+}
+

--- a/modules/cloudwatch_logzio/versions.tf
+++ b/modules/cloudwatch_logzio/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is a nearly 100% as-is extraction of the CloudWatch Logz.io log shipping module from OpsCore. There are definitely improvements we can make to it such as bringing it up to date with the latest log shipper that Logz.io has to offer. But for now, this will help with the V4 directory structure refactoring in OpsCore. Other apps can also use this to send logs.