### PR TITLE
TASS-945: Allow additional SQL stmts for debezium_database_user

### DIFF
--- a/modules/debezium_database_user/postgres_user.tf
+++ b/modules/debezium_database_user/postgres_user.tf
@@ -13,6 +13,7 @@ docker run -e PGPASSWORD="${var.database_admin_password}" --rm --entrypoint="" $
     '${var.debezium_password}' VALID UNTIL 'infinity' IN ROLE rds_replication;
     GRANT USAGE ON SCHEMA public TO debezium;
     GRANT SELECT, INSERT, DELETE ON TABLE ${var.debezium_events_table} TO ${var.debezium_username};
+    ${var.additional_commands}
   "
 EOF
 

--- a/modules/debezium_database_user/variables.tf
+++ b/modules/debezium_database_user/variables.tf
@@ -3,7 +3,7 @@ variable "database_address" {
 }
 
 variable "postgres_version" {
-  type = string
+  type    = string
   default = "latest"
 }
 
@@ -12,12 +12,12 @@ variable "database_name" {
 }
 
 variable "database_port" {
-  type = string
+  type    = string
   default = "5432"
 }
 
 variable "debezium_events_table" {
-  type = string
+  type    = string
   default = "message_bus_subscription_events"
 }
 
@@ -26,7 +26,7 @@ variable "debezium_password" {
 }
 
 variable "debezium_username" {
-  type = string
+  type    = string
   default = "debezium"
 }
 
@@ -36,4 +36,10 @@ variable "database_admin_username" {
 
 variable "database_admin_password" {
   type = string
+}
+
+variable "additional_commands" {
+  type        = string
+  description = "Additional SQL statements to execute when creating the user"
+  default     = ""
 }


### PR DESCRIPTION
Some apps (who shall remain nameless), have an "extensions" schema that extensions are added to.
This means, each user needs to have access to that schema to invoke some extension functions (e.g. uuid_gen).

This puts an empty placeholder for such statements.