### PR TITLE
helm_secrets module

### DIFF
--- a/modules/helm_secrets/main.tf
+++ b/modules/helm_secrets/main.tf
@@ -1,0 +1,114 @@
+resource "aws_kms_key" "helm_secrets" {
+  description = "secret encryption/decryption via helm secrets plugin/Mozilla SOPS"
+  enable_key_rotation = true
+  multi_region = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  # TODO: right now developer SSO roles have unfettered access to account
+  # in the future we may create multiple classes of users, where the less
+  # privileged class will have key access, and the privileged class admin access.
+  # Define both admin and usage access here so we just need to swap out role IDs later.
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+        {
+            Sid = "Enable IAM User Permissions",
+            Effect = "Allow",
+            Principal = {
+                "AWS": "arn:aws:iam::${var.aws_account_id}:root"
+            },
+            Action = "kms:*",
+            Resource = "*"
+        },
+        {
+            Sid = "Allow access for Key SRE Administrators",
+            Effect = "Allow",
+            Principal = {
+                "AWS": "arn:aws:iam::${var.aws_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_${var.admin_sso_role_id}"
+            },
+            Action = [
+                "kms:Create*",
+                "kms:Describe*",
+                "kms:Enable*",
+                "kms:List*",
+                "kms:Put*",
+                "kms:Update*",
+                "kms:Revoke*",
+                "kms:Disable*",
+                "kms:Get*",
+                "kms:Delete*",
+                "kms:TagResource",
+                "kms:UntagResource",
+                "kms:ScheduleKeyDeletion",
+                "kms:CancelKeyDeletion"
+            ],
+            Resource = "*"
+        },
+        {
+            Sid = "Allow access for Key Team Administrators",
+            Effect = "Allow",
+            Principal = {
+                "AWS": "arn:aws:iam::${var.aws_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DeveloperAccess_${var.developer_sso_role_id}"
+            },
+            Action = [
+                "kms:Create*",
+                "kms:Describe*",
+                "kms:Enable*",
+                "kms:List*",
+                "kms:Put*",
+                "kms:Update*",
+                "kms:Revoke*",
+                "kms:Disable*",
+                "kms:Get*",
+                "kms:Delete*",
+                "kms:TagResource",
+                "kms:UntagResource",
+                "kms:ScheduleKeyDeletion",
+                "kms:CancelKeyDeletion"
+            ],
+            Resource = "*"
+        },
+        {
+            Sid = "Allow use of the key",
+            Effect = "Allow",
+            Principal = {
+                "AWS": "arn:aws:iam::${var.aws_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DeveloperAccess_${var.developer_sso_role_id}"
+            },
+            Action = [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            Resource = "*"
+        },
+        {
+            Sid = "Allow attachment of persistent resources",
+            Effect = "Allow",
+            Principal = {
+                "AWS": "arn:aws:iam::${var.aws_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DeveloperAccess_${var.developer_sso_role_id}"
+            },
+            Action = [
+                "kms:CreateGrant",
+                "kms:ListGrants",
+                "kms:RevokeGrant"
+            ],
+            Resource = "*",
+            Condition = {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                }
+            }
+        }
+    ]
+  })
+}
+
+resource "aws_kms_alias" "kms_alias" {
+  name          = "alias/${var.aws_profile}-helm-secrets"
+  target_key_id = aws_kms_key.helm_secrets.key_id
+}

--- a/modules/helm_secrets/outputs.tf
+++ b/modules/helm_secrets/outputs.tf
@@ -1,0 +1,3 @@
+output "kms_key_arn" {
+  value = aws_kms_key.helm_secrets.arn
+}

--- a/modules/helm_secrets/variables.tf
+++ b/modules/helm_secrets/variables.tf
@@ -1,0 +1,16 @@
+variable "aws_profile" {
+  description = "The AWS account you want to use, as defined by your ~/.aws/credentials file."
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID"
+}
+
+variable "admin_sso_role_id" {
+  description = "SRE/admin SSO role ID"
+}
+
+variable "developer_sso_role_id" {
+  description = "Team developer SSO role ID"
+}
+

--- a/modules/helm_secrets/versions.tf
+++ b/modules/helm_secrets/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
I had originally hardcoded these roles into the individual team repos, but have since realized that this didn't make sense for a couple of reasons:

- it wasn't DRY
- we should have different keys for test and production accounts so that we have the option of only granting team access to non-production keys. Therefore, these role IDs should be parameterized, and as parameters this becomes a little more complicated to manage without this centralization
