### PR TITLE
SRE2-1549: Update helm_secrets module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,9 @@ to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
 ### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
+
+* Changed `helm_secrets` module to remove references to hardcoded SSO role, redundant var.account_id and var.aws_profile in favour of standardized var.environment_name as aws_profile should be used for authentication only
 
 ## [23.2.0] - 2022-05-04
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When you are happy with your changes:
 
 1. Add description of changes to the top of the [CHANGELOG](./CHANGELOG.md) file, under the `## [Unreleased]` section.
 1. Create a Pull Request.
-1. Notify #tass Slack channel for a review.
+1. Notify #sre Slack channel for a review.
    - As maintainers, SRE would like to keep up to date with any changes.
 1. Once approved and all comments have been resolved, [release a new version](#release-a-new-version).
    - Everyone in Product Development has write access.

--- a/modules/helm_secrets/main.tf
+++ b/modules/helm_secrets/main.tf
@@ -1,5 +1,7 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_kms_key" "helm_secrets" {
-  description = "secret encryption/decryption via helm secrets plugin/Mozilla SOPS"
+  description = "Key for encryption/decryption of secrets via helm secrets plugin/Mozilla SOPS"
   enable_key_rotation = true
   multi_region = true
 
@@ -10,105 +12,105 @@ resource "aws_kms_key" "helm_secrets" {
   # TODO: right now developer SSO roles have unfettered access to account
   # in the future we may create multiple classes of users, where the less
   # privileged class will have key access, and the privileged class admin access.
-  # Define both admin and usage access here so we just need to swap out role IDs later.
+  # Define both admin and usage access here so we just need to swap out roles later.
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
-        {
-            Sid = "Enable IAM User Permissions",
-            Effect = "Allow",
-            Principal = {
-                "AWS": "arn:aws:iam::${var.aws_account_id}:root"
-            },
-            Action = "kms:*",
-            Resource = "*"
+      {
+        Sid = "Enable IAM policies",
+        Effect = "Allow",
+        Principal = {
+          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         },
-        {
-            Sid = "Allow access for Key SRE Administrators",
-            Effect = "Allow",
-            Principal = {
-                "AWS": "arn:aws:iam::${var.aws_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_${var.admin_sso_role_id}"
-            },
-            Action = [
-                "kms:Create*",
-                "kms:Describe*",
-                "kms:Enable*",
-                "kms:List*",
-                "kms:Put*",
-                "kms:Update*",
-                "kms:Revoke*",
-                "kms:Disable*",
-                "kms:Get*",
-                "kms:Delete*",
-                "kms:TagResource",
-                "kms:UntagResource",
-                "kms:ScheduleKeyDeletion",
-                "kms:CancelKeyDeletion"
-            ],
-            Resource = "*"
+        Action = "kms:*",
+        Resource = "*"
+      },
+      {
+        Sid = "Allow access for Administrators",
+        Effect = "Allow",
+        Principal = {
+          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${var.admin_sso_role}"
         },
-        {
-            Sid = "Allow access for Key Team Administrators",
-            Effect = "Allow",
-            Principal = {
-                "AWS": "arn:aws:iam::${var.aws_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DeveloperAccess_${var.developer_sso_role_id}"
-            },
-            Action = [
-                "kms:Create*",
-                "kms:Describe*",
-                "kms:Enable*",
-                "kms:List*",
-                "kms:Put*",
-                "kms:Update*",
-                "kms:Revoke*",
-                "kms:Disable*",
-                "kms:Get*",
-                "kms:Delete*",
-                "kms:TagResource",
-                "kms:UntagResource",
-                "kms:ScheduleKeyDeletion",
-                "kms:CancelKeyDeletion"
-            ],
-            Resource = "*"
+        Action = [
+          "kms:Create*",
+          "kms:Describe*",
+          "kms:Enable*",
+          "kms:List*",
+          "kms:Put*",
+          "kms:Update*",
+          "kms:Revoke*",
+          "kms:Disable*",
+          "kms:Get*",
+          "kms:Delete*",
+          "kms:TagResource",
+          "kms:UntagResource",
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid = "Allow access for Developers",
+        Effect = "Allow",
+        Principal = {
+          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${var.developer_sso_role}"
         },
-        {
-            Sid = "Allow use of the key",
-            Effect = "Allow",
-            Principal = {
-                "AWS": "arn:aws:iam::${var.aws_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DeveloperAccess_${var.developer_sso_role_id}"
-            },
-            Action = [
-                "kms:Encrypt",
-                "kms:Decrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-                "kms:DescribeKey"
-            ],
-            Resource = "*"
+        Action = [
+          "kms:Create*",
+          "kms:Describe*",
+          "kms:Enable*",
+          "kms:List*",
+          "kms:Put*",
+          "kms:Update*",
+          "kms:Revoke*",
+          "kms:Disable*",
+          "kms:Get*",
+          "kms:Delete*",
+          "kms:TagResource",
+          "kms:UntagResource",
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid = "Allow use of the key",
+        Effect = "Allow",
+        Principal = {
+          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${var.developer_sso_role}"
         },
-        {
-            Sid = "Allow attachment of persistent resources",
-            Effect = "Allow",
-            Principal = {
-                "AWS": "arn:aws:iam::${var.aws_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DeveloperAccess_${var.developer_sso_role_id}"
-            },
-            Action = [
-                "kms:CreateGrant",
-                "kms:ListGrants",
-                "kms:RevokeGrant"
-            ],
-            Resource = "*",
-            Condition = {
-                "Bool": {
-                    "kms:GrantIsForAWSResource": "true"
-                }
-            }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid = "Allow attachment of persistent resources",
+        Effect = "Allow",
+        Principal = {
+          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${var.developer_sso_role}"
+        },
+        Action = [
+          "kms:CreateGrant",
+          "kms:ListGrants",
+          "kms:RevokeGrant"
+        ],
+        Resource = "*",
+        Condition = {
+          "Bool": {
+            "kms:GrantIsForAWSResource": "true"
+          }
         }
+      }
     ]
   })
 }
 
 resource "aws_kms_alias" "kms_alias" {
-  name          = "alias/${var.aws_profile}-helm-secrets"
+  name          = "alias/${var.environment_name}-helm-secrets"
   target_key_id = aws_kms_key.helm_secrets.key_id
 }

--- a/modules/helm_secrets/variables.tf
+++ b/modules/helm_secrets/variables.tf
@@ -1,16 +1,10 @@
-variable "aws_profile" {
-  description = "The AWS account you want to use, as defined by your ~/.aws/credentials file."
+variable "environment_name" {
 }
 
-variable "aws_account_id" {
-  description = "AWS account ID"
+variable "admin_sso_role" {
+  description = "SRE/admin SSO role"
 }
 
-variable "admin_sso_role_id" {
-  description = "SRE/admin SSO role ID"
+variable "developer_sso_role" {
+  description = "Team developer SSO role"
 }
-
-variable "developer_sso_role_id" {
-  description = "Team developer SSO role ID"
-}
-

--- a/modules/helm_secrets/versions.tf
+++ b/modules/helm_secrets/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}


### PR DESCRIPTION
- Changed `helm_secrets` module to remove references to hardcoded SSO role (AdministratorAccess, DeveloperAccess are prone to change and should be handled as a whole string with role name, not just the suffix)
- Removed redundant var.account_id that can be obtained from caller identity
- Changed var.aws_profile to var.environment_name to intentionally avoid using aws profile as a resource name prefix. aws profile can change at the module user discretion and should be used only for provider authentication/configuration at the root module level. Existing modules can define var.environment_name as the string that matches the existing resources so we don't have to recreate them
- I noticed [references to this module are not versioned](https://github.com/search?q=org%3Anulogy+helm_secrets&type=code), and this is a breaking change. I will make additional pull requests to update those references to avoid breaking changes