### PR TITLE
SRE2-1549: Adds multi-region kms key module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,8 @@ to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
+
+* Added `kms_multi_region_key` to be used initially by `helm_secrets` module to encrypt/decrypt secrets using a KMS key that is highly available across primary and replica regions 
 
 ## [23.2.0] - 2022-05-04
 

--- a/modules/kms_multi_region_key/main.tf
+++ b/modules/kms_multi_region_key/main.tf
@@ -1,0 +1,107 @@
+data "aws_caller_identity" "current" {}
+
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-overview.html
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid = "Enable IAM policies"
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow access for Key Administrators"
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${var.administrator_role}"]
+    }
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow use of the key"
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${var.administrator_role}",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${var.developer_role}"
+      ]
+    }
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow attachment of persistent resources"
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:RevokeGrant"
+    ]
+    resources = ["*"]
+    condition {
+      test = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values = ["true"]
+    }
+  }
+}
+
+resource "aws_kms_key" "primary" {
+  description         = "${var.description}"
+  enable_key_rotation = true
+  multi_region        = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  policy = data.aws_iam_policy_document.policy.json
+}
+
+resource "aws_kms_alias" "kms_alias" {
+  name          = "alias/${var.environment_name}"
+  target_key_id = aws_kms_key.primary.key_id
+}
+
+resource "aws_kms_replica_key" "replica" {
+  provider        = aws.replica
+  description     = "${var.description}"
+  primary_key_arn = aws_kms_key.primary.arn
+  policy          = data.aws_iam_policy_document.policy.json
+}
+
+resource "aws_kms_alias" "replica" {
+  provider      = aws.replica
+  name          = "alias/${var.environment_name}"
+  target_key_id = aws_kms_replica_key.replica.key_id
+}

--- a/modules/kms_multi_region_key/outputs.tf
+++ b/modules/kms_multi_region_key/outputs.tf
@@ -1,0 +1,7 @@
+output "kms_key_arn" {
+  value = aws_kms_key.primary.arn
+}
+
+output "kms_key_replica_arn" {
+  value = aws_kms_replica_key.replica.arn
+}

--- a/modules/kms_multi_region_key/setup.tf
+++ b/modules/kms_multi_region_key/setup.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.7.0"
+      configuration_aliases = [ aws.replica ]
+    }
+  }
+}

--- a/modules/kms_multi_region_key/variables.tf
+++ b/modules/kms_multi_region_key/variables.tf
@@ -1,0 +1,15 @@
+variable "environment_name" {
+  description = "Environment name. Used for tagging."
+}
+
+variable "description" {
+  default = "Multi-Region key"
+}
+
+variable "administrator_role" {
+  description = "Administrator role provisioned by AWS SSO"
+}
+
+variable "developer_role" {
+  description = "Developer role provisioned by AWS SSO"
+}


### PR DESCRIPTION
- Added `kms_multi_region_key` to be used initially by `helm_secrets` module to encrypt/decrypt secrets using a KMS key that is highly available across primary and replica regions 