### PR TITLE
SRE2-1653 change ECR image tag immutibility default

### DIFF
--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
 
 variable "image_tag_mutability" {
   description = "The tag mutability setting for the repository. Must be one of: MUTABLE or IMMUTABLE"
-  default     = "MUTABLE"
+  default     = "IMMUTABLE"
 }
 
 variable "skip" {


### PR DESCRIPTION
Do we have a use case for needing mutable images? If not, I propose changing this default. If we aren't sure, I think the better default is the more secure option, and then we can adjust this on a per-repo basis.