### PR TITLE
SRE2-1700: Adds cloudfront module with support to WAF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
+
+* Adds `cloudfront` module with the option to set `web_acl_id` with WAF configuration
+* Generalizes pattern used on different systems for consistency
+* Fixes [configuration changes](https://github.com/hashicorp/terraform-provider-aws/issues/28353) to bucket ACLs introduced by AWS on April, 2023
 
 ## [23.8.0] - 2023-03-27
 

--- a/modules/cloudfront/files/404.html
+++ b/modules/cloudfront/files/404.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>The page you were looking for doesn't exist (404)</title>
+  <style type="text/css">
+    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
+    div.dialog {
+      width: 25em;
+      padding: 0 4em;
+      margin: 4em auto 0 auto;
+      border: 1px solid #ccc;
+      border-right-color: #999;
+      border-bottom-color: #999;
+    }
+    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/404.html -->
+  <div class="dialog">
+    <h1>The page you were looking for doesn't exist.</h1>
+    <p>You may have mistyped the address or the page may have moved.</p>
+  </div>
+</body>
+</html>

--- a/modules/cloudfront/files/500.html
+++ b/modules/cloudfront/files/500.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+  <title>Error - PackManager</title>
+	<style type="text/css">
+		body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
+		div.dialog {
+			width: 40em;
+			padding: 0 4em;
+			margin: 4em auto 0 auto;
+			border: 1px solid #ccc;
+			border-right-color: #999;
+			border-bottom-color: #999;
+		}
+		h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+	</style>
+</head>
+
+<body>
+  <div class="dialog">
+	<h1>We're sorry, but PackManager encountered an<br/> error performing the last action you requested.</h1>
+		<p>Nulogy support has been automatically notified of the error.<br />
+	 	You can <a href="mailto:support@nulogy.com?subject=PackManager Error">email us at support@nulogy.com</a> for further assistance.</p>
+    <p>In the event of a service disruption, please refer to our <a href="http://status.nulogy.net">status blog</a> for more information.</p>
+  </div>
+</body>
+</html>

--- a/modules/cloudfront/files/maintenance.html
+++ b/modules/cloudfront/files/maintenance.html
@@ -1,0 +1,52 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
+  <title>System down for maintenance</title>
+
+  <style type="text/css">
+    div.outer {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 500px;
+      height: 300px;
+      margin-left: -260px; 
+      margin-top: -150px;
+    }
+
+    .DialogBody {
+      margin: 0;
+      padding: 10px;
+      text-align: left;
+      border: 1px solid #ccc;
+      border-right: 1px solid #999;
+      border-bottom: 1px solid #999;
+      background-color: #fff;
+    }
+
+    body { background-color: #fff; }
+  </style>
+</head>
+
+<body>
+
+  <div class="outer">
+     <div class="DialogBody" style="text-align: center;">
+       <div style="text-align: center; width: 200px; margin: 0 auto;">
+         <p style="color: red; font-size: 16px; line-height: 20px;">
+           The system is down for updates.
+         </p>
+         <p style="color: #666;">
+           It'll be back shortly.
+         </p>
+       </div>
+     </div>
+  </div>
+
+</body>
+</html>

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -10,8 +10,9 @@ locals {
   origin = concat(
     [
      {
-       domain_name = aws_s3_bucket_website_configuration.cloudfront.website_endpoint
-       origin_id   = "maintenance-errors"
+       domain_name            = aws_s3_bucket_website_configuration.cloudfront.website_endpoint
+       origin_id              = "maintenance-errors"
+       origin_protocol_policy = "http-only"
      }
     ],
     var.origin
@@ -46,7 +47,7 @@ resource "aws_cloudfront_distribution" "this" {
         https_port               = 443
         origin_read_timeout      = 60
         origin_keepalive_timeout = 5
-        origin_protocol_policy   = "https-only"
+        origin_protocol_policy   = lookup(i.value, "origin_protocol_policy", "https-only")
         origin_ssl_protocols     = ["TLSv1.1", "TLSv1.2"]
       }
 

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -1,0 +1,159 @@
+locals {
+  tags = merge(
+    {
+      Name           = "${var.environment_name} CloudFront Distribution"
+      resource_group = var.environment_name
+    },
+    var.tags,
+  )
+
+  origin = concat(
+    [
+     {
+       domain_name = aws_s3_bucket_website_configuration.cloudfront.website_endpoint
+       origin_id   = "maintenance-errors"
+     }
+    ],
+    var.origin
+  )
+
+  maintenance = var.default_origin_id == "maintenance-errors"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  aliases     = var.aliases
+  enabled     = true
+  price_class = "PriceClass_100"
+  web_acl_id  = var.web_acl_id
+  tags        = local.tags
+
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.logs.bucket_domain_name
+    prefix          = null
+  }
+
+  dynamic "origin" {
+    for_each = local.origin
+    iterator = i
+
+    content {
+      domain_name = i.value.domain_name
+      origin_id   = i.value.origin_id
+
+      custom_origin_config {
+        http_port                = 80
+        https_port               = 443
+        origin_read_timeout      = 60
+        origin_keepalive_timeout = 5
+        origin_protocol_policy   = "https-only"
+        origin_ssl_protocols     = ["TLSv1.1", "TLSv1.2"]
+      }
+
+      dynamic "custom_header" {
+        for_each = lookup(i.value, "custom_header", [])
+
+        content {
+          name  = custom_header.value.name
+          value = custom_header.value.value
+        }
+      }
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = var.default_origin_id
+
+    forwarded_values {
+      query_string = true
+      headers      = [local.maintenance ? "None" : "*"]
+
+      cookies {
+        forward = local.maintenance ? "none" : "all"
+      }
+    }
+    default_ttl            = 0
+    max_ttl                = 0
+    min_ttl                = 0
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  dynamic "ordered_cache_behavior" {
+    for_each = var.ordered_cache_behavior
+    iterator = i
+
+    content {
+      path_pattern           = i.value.path_pattern
+      target_origin_id       = i.value.target_origin_id
+      viewer_protocol_policy = lookup(i.value, "viewer_protocol_policy", "redirect-to-https")
+      allowed_methods        = lookup(i.value, "allowed_methods", ["GET", "HEAD", "OPTIONS"])
+      cached_methods         = lookup(i.value, "cached_methods", ["GET", "HEAD", "OPTIONS"])
+      compress               = lookup(i.value, "compress", true)
+      min_ttl                = lookup(i.value, "min_ttl", null)
+      default_ttl            = lookup(i.value, "default_ttl", null)
+      max_ttl                = lookup(i.value, "max_ttl", null)
+
+      forwarded_values {
+        query_string = lookup(i.value, "query_string", false)
+
+        cookies {
+          forward = lookup(i.value, "cookies_forward", "none")
+        }
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = lookup(var.viewer_certificate, "acm_certificate_arn", null)
+    minimum_protocol_version = lookup(var.viewer_certificate, "minimum_protocol_version", "TLSv1.2_2018")
+    ssl_support_method       = lookup(var.viewer_certificate, "ssl_support_method", "sni-only")
+  }
+
+  custom_error_response {
+    # This case handles GET calls made during maintenance
+    error_code         = 404
+    response_code      = local.maintenance ? 503 : 0
+    response_page_path = local.maintenance ? "/maintenance.html" : ""
+  }
+
+  custom_error_response {
+    # This case handles POST, PUT and DELETE calls made during maintenance
+    error_code         = 405
+    response_code      = local.maintenance ? 503 : 0
+    response_page_path = local.maintenance ? "/maintenance.html" : ""
+  }
+
+  custom_error_response {
+    # This case handles OPTIONS calls made during maintenance
+    error_code         = 400
+    response_code      = local.maintenance ? 503 : 0
+    response_page_path = local.maintenance ? "/maintenance.html" : ""
+  }
+
+  custom_error_response {
+    error_code         = 504
+    response_code      = 504
+    response_page_path = "/500.html"
+  }
+
+  custom_error_response {
+    error_code         = 503
+    response_code      = 503
+    response_page_path = "/503.html"
+  }
+
+  custom_error_response {
+    error_code         = 502
+    response_code      = 502
+    response_page_path = "/500.html"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+      locations        = []
+    }
+  }
+}

--- a/modules/cloudfront/outputs.tf
+++ b/modules/cloudfront/outputs.tf
@@ -2,6 +2,10 @@ output "id" {
   value = aws_cloudfront_distribution.this.id
 }
 
+output "arn" {
+  value = aws_cloudfront_distribution.this.arn
+}
+
 output "domain_name" {
   value = aws_cloudfront_distribution.this.domain_name
 }

--- a/modules/cloudfront/outputs.tf
+++ b/modules/cloudfront/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = aws_cloudfront_distribution.this.id
+}
+
+output "domain_name" {
+  value = aws_cloudfront_distribution.this.domain_name
+}

--- a/modules/cloudfront/s3.tf
+++ b/modules/cloudfront/s3.tf
@@ -1,0 +1,147 @@
+resource "aws_s3_bucket" "logs" {
+  bucket_prefix            = "${var.environment_name}-cf-logs-"
+  force_destroy            = "true"
+  tags                     = var.tags
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "expiration"
+    status = "Enabled"
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket" "cloudfront" {
+  bucket_prefix = "${var.environment_name}-cf-"
+  force_destroy = "true"
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "cloudfront" {
+  bucket = aws_s3_bucket.cloudfront.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "cloudfront" {
+  bucket = aws_s3_bucket.cloudfront.id
+
+  index_document {
+    suffix = "no file - deliberately cause a 404 which gets transformed into a 503 by cloudfront"
+  }
+
+  error_document {
+    key = "maintenance.html"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "cloudfront" {
+  bucket = aws_s3_bucket.cloudfront.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+data "aws_iam_policy_document" "cloudfront" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.cloudfront.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.this.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudfront" {
+  bucket = aws_s3_bucket.cloudfront.id
+  policy = data.aws_iam_policy_document.cloudfront.json
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudfront" {
+  bucket = aws_s3_bucket.cloudfront.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_object" "page_500" {
+  bucket       = aws_s3_bucket.cloudfront.id
+  content_type = "text/html"
+  key          = "500.html"
+  source       = "files/500.html"
+  etag         = filemd5("files/500.html")
+}
+
+resource "aws_s3_bucket_object" "page_404" {
+  bucket       = aws_s3_bucket.cloudfront.id
+  content_type = "text/html"
+  key          = "404.html"
+  source       = "files/404.html"
+  etag         = filemd5("files/404.html")
+}
+
+resource "aws_s3_bucket_object" "maintenance" {
+  bucket       = aws_s3_bucket.cloudfront.id
+  content_type = "text/html"
+  key          = "maintenance.html"
+  source       = "files/maintenance.html"
+  etag         = filemd5("files/maintenance.html")
+}

--- a/modules/cloudfront/variables.tf
+++ b/modules/cloudfront/variables.tf
@@ -1,0 +1,46 @@
+variable "environment_name" {
+  description = "Environment name. Used for naming and tagging."
+  type        = string
+}
+
+variable "default_origin_id" {
+  description = "Set default origin ID to maintenance-errors, please override to app via configuration."
+  type        = string
+  default     = "maintenance-errors"
+}
+
+variable "aliases" {
+  description = "Extra CNAMEs (alternate domain names), if any, for this distribution."
+  type        = list(string)
+  default     = null
+}
+
+variable "origin" {
+  description = "One or more origins for this distribution (multiples allowed)."
+  type        = any
+  default     = []
+}
+
+variable "ordered_cache_behavior" {
+  description = "An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0."
+  type        = any
+  default     = []
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "viewer_certificate" {
+  description = "The SSL configuration for this distribution"
+  type        = any
+  default     = {}
+}
+
+variable "web_acl_id" {
+  description = "If you're using AWS WAF to filter CloudFront requests, the Id of the AWS WAF web ACL that is associated with the distribution. The WAF Web ACL must exist in the WAF Global (CloudFront) region and the credentials configuring this argument must have waf:GetWebACL permissions assigned. If using WAFv2, provide the ARN of the web ACL."
+  type        = string
+  default     = null
+}

--- a/modules/cloudfront/versions.tf
+++ b/modules/cloudfront/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
 * Adds `cloudfront` module with the option to set `web_acl_id` with WAF configuration
 * Generalizes pattern used on different systems for consistency
 * Fixes [configuration changes](https://github.com/hashicorp/terraform-provider-aws/issues/28353) to bucket ACLs introduced by AWS on April, 2023
