### PR TITLE
SPAR-148: Wire additional_commands into data_platform_database_user grant

### DIFF
--- a/modules/data_platform_database_user/grant_usage_in_ops.sql.tpl
+++ b/modules/data_platform_database_user/grant_usage_in_ops.sql.tpl
@@ -2,3 +2,4 @@ CREATE ROLE ${data_platform_database_user__username} with LOGIN PASSWORD '${data
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO ${data_platform_database_user__username};
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO ${data_platform_database_user__username};
 GRANT USAGE ON SCHEMA extensions, public TO ${data_platform_database_user__username};
+${additional_commands}

--- a/modules/data_platform_database_user/main.tf
+++ b/modules/data_platform_database_user/main.tf
@@ -20,6 +20,7 @@ data "template_file" "grant_usage_in_ops_query" {
   vars     = {
      data_platform_database_user__username = var.data_platform_database_user__username
      data_platform_database_user__password = var.data_platform_database_user__password
+     additional_commands                   = var.additional_commands
   }
 }
 


### PR DESCRIPTION
## What

Thread the existing `additional_commands` variable into `data_platform_database_user`'s grant so it actually runs. It's declared and documented ("Additional SQL statements to execute when creating the user") but never interpolated into `grant_usage_in_ops.sql.tpl`, so setting it today is a **silent no-op**. This wires it in (and into the `grant_command` trigger), matching how `debezium_database_user` already folds `additional_grant_statements` into its `CREATE ROLE …` command.

## Why

PackManager is rolling out PostgreSQL Row-Level Security. The `data_platform` role reads all tenant data (it's created `IN ROLE readonly`), so once RLS policies are enabled it fail-closes to zero rows unless it has `BYPASSRLS`. We need the role to be **created with** `BYPASSRLS`, the same way `debezium` is. With this change, the PackManager wrapper can pass:

```hcl
additional_commands = "ALTER ROLE ${var.data_platform_database_user__username} BYPASSRLS;"
```

## Reviewer notes / caveats

- **Covers fresh creation; not safe for recreating an existing role.** Because `additional_commands` feeds `grant_command` (a `null_resource` trigger), changing it on a *live* environment triggers a replace → `DROP ROLE`. The revoke template (`drop_user_in_ops.sql.tpl`) only cancels the `ALTER DEFAULT PRIVILEGES` rule; it does **not** revoke the `SELECT` grants that rule already produced on existing tables, so `DROP ROLE` fails on a long-lived role (`pg_shdepend` dependencies). Existing roles should be updated with an in-place `ALTER ROLE … BYPASSRLS` instead.
- **Optional follow-up:** make the revoke template the true inverse of the grant (`REVOKE … ON ALL TABLES …` / `DROP OWNED BY …` before `DROP ROLE`) so a recreate can succeed. Out of scope here.
- **Needs a release tag** after merge so consumers can bump their `?ref=`.

## Test

`additional_commands` defaults to `""` (renders to a harmless empty line), so existing callers are unaffected.
